### PR TITLE
Add __version__ attribute

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -34,6 +34,7 @@ jobs:
       run: |
         VERSION=${{ github.event.release.tag_name }}
         sed -i 's/__version__ = ".*"/__version__ = "'${VERSION}'"/' _version.py
+        sed -i "s/version='.*'/version='${VERSION}'/" setup.py
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Update package version
       run: |
         VERSION=${{ github.event.release.tag_name }}
-        sed -i "s/version='.*'/version='${VERSION}'/" setup.py
+        sed -i 's/__version__ = ".*"/__version__ = "'${VERSION}'"/' _version.py
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/datastew/__init__.py
+++ b/datastew/__init__.py
@@ -1,7 +1,7 @@
 from .visualisation import *
 from .mapping import *
 from .embedding import *
-from _version import __version__
+from ._version import __version__
 
 # Importing submodules to expose their attributes if needed
 from .process import mapping, parsing

--- a/datastew/__init__.py
+++ b/datastew/__init__.py
@@ -1,6 +1,7 @@
 from .visualisation import *
 from .mapping import *
 from .embedding import *
+from _version import __version__
 
 # Importing submodules to expose their attributes if needed
 from .process import mapping, parsing

--- a/datastew/_version.py
+++ b/datastew/_version.py
@@ -1,0 +1,1 @@
+__version__ = "0.4.0" # will be substituted in publish workflow

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 import os
-import re
 
 from setuptools import setup, find_packages
 
@@ -14,18 +13,9 @@ try:
 except FileNotFoundError:
     long_description = DESCRIPTION
 
-VERSION_FILE = "datastew/_version.py"
-version = open(VERSION_FILE, "rt").read()
-VERSION_RE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-match_object = re.search(VERSION_RE, version, re.M)
-if match_object:
-    version_str = match_object.group(1)
-else:
-    raise RuntimeError("Unable to find version string in %s." % (VERSION_FILE,))
-
 setup(
     name='datastew',
-    version=version_str,
+    version='0.4.0', # will be substituted in publish workflow
     packages=find_packages(),  # This will automatically find all packages and sub-packages
     url='https://github.com/SCAI-BIO/datastew',
     license='Apache-2.0 license',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import io
 import os
+import re
+
 from setuptools import setup, find_packages
 
 DESCRIPTION = 'Intelligent data steward toolbox using Large Language Model embeddings for automated Data-Harmonization.'
@@ -12,9 +14,18 @@ try:
 except FileNotFoundError:
     long_description = DESCRIPTION
 
+VERSION_FILE = "datastew/_version.py"
+version = open(VERSION_FILE, "rt").read()
+VERSION_RE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+match_object = re.search(VERSION_RE, version, re.M)
+if match_object:
+    version_str = match_object.group(1)
+else:
+    raise RuntimeError("Unable to find version string in %s." % (VERSION_FILE,))
+
 setup(
     name='datastew',
-    version='0.1.0',  # will be substituted in publish workflow
+    version=version_str,
     packages=find_packages(),  # This will automatically find all packages and sub-packages
     url='https://github.com/SCAI-BIO/datastew',
     license='Apache-2.0 license',

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,15 @@
+import re
+from unittest import TestCase
+import datastew
+
+
+class Test(TestCase):
+    def test_canonical_version(self):
+        version = datastew.__version__
+        return (
+            re.match(
+                r"^([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$",
+                version,
+            )
+            is not None
+        )


### PR DESCRIPTION
- Added _version.py to hold version value in `__version__`
- Changed the publish action to substitute the version in `_version.py` instead of `setup.py` (the regex needs to be checked).
- Imported `__version__` from `_version.py` to `__init__.py` to expose the attribute. The user should be able to print the version of the package with the command `datastew.__version__`.

closes #38 