### PR TITLE
feat: enable JSONL import generation from OHDSI without vector embeddings

### DIFF
--- a/datastew/scripts/ohdsi_to_json.py
+++ b/datastew/scripts/ohdsi_to_json.py
@@ -1,7 +1,0 @@
-from datastew.embedding import Vectorizer
-from datastew.process.jsonl_adapter import WeaviateJsonlConverter
-
-json_converter = WeaviateJsonlConverter("resources/results")
-vectorizer = Vectorizer()
-
-json_converter.from_ohdsi("resources/CONCEPT.csv", vectorizer)

--- a/datastew/scripts/ohdsi_to_jsonl.py
+++ b/datastew/scripts/ohdsi_to_jsonl.py
@@ -1,0 +1,5 @@
+from datastew.process.jsonl_adapter import WeaviateJsonlConverter
+
+jsonl_converter = WeaviateJsonlConverter("resources/results")
+
+jsonl_converter.from_ohdsi("resources/CONCEPT.csv")


### PR DESCRIPTION
I enabled the WeaviateJsonlConverter to generate JSONL import files from OHDSI.csv without including the vector embeddings.