### PR TITLE
refactor: enable OLS vectorizer support

### DIFF
--- a/datastew/process/ols.py
+++ b/datastew/process/ols.py
@@ -18,6 +18,7 @@ class OLSTerminologyImportTask:
         ontology_id: str,
         ols_api_base_url: str = "https://www.ebi.ac.uk/ols4/api/",
         page_size: int = 200,
+        use_weaviate_vectorizer: bool = False,
     ):
         logging.getLogger().setLevel(logging.INFO)
         self.vectorizer = vectorizer
@@ -26,6 +27,7 @@ class OLSTerminologyImportTask:
         self.terminology = Terminology(self.ontology_name, self.ontology_id)
         self.OLS_BASE_URL = ols_api_base_url
         self.page_size = page_size
+        self.use_weaviate_vectorizer = use_weaviate_vectorizer
         self.num_pages = self.get_number_of_pages()
         self.current_page = 0
 
@@ -56,15 +58,23 @@ class OLSTerminologyImportTask:
                     descriptions.append(term["description"])
                 else:
                     descriptions.append(term["label"])
-            embeddings = self.vectorizer.get_embeddings(descriptions)
-            model_name = self.vectorizer.model_name
+            if not self.use_weaviate_vectorizer:
+                embeddings = self.vectorizer.get_embeddings(descriptions)
+                model_name = self.vectorizer.model_name
             concepts = []
             mappings = []
-            for identifier, label, description, embedding in zip(identifiers, labels, descriptions, embeddings):
-                concept = Concept(self.terminology, label, identifier)
-                concepts.append(concept)
-                mapping = Mapping(concept, description, embedding, model_name)
-                mappings.append(mapping)
+            if not self.use_weaviate_vectorizer:
+                for identifier, label, description, embedding in zip(identifiers, labels, descriptions, embeddings):
+                    concept = Concept(self.terminology, label, identifier)
+                    concepts.append(concept)
+                    mapping = Mapping(concept, description, embedding, model_name)
+                    mappings.append(mapping)
+            else:
+                for identifier, label, description in zip(identifiers, labels, descriptions):
+                    concept = Concept(self.terminology, label, identifier)
+                    concepts.append(concept)
+                    mapping = Mapping(concept, description)
+                    mappings.append(mapping)
             return concepts, mappings
         except Exception as e:
             logging.error(f"Failed to fetch concepts and descriptions from OLS for page {page}: {str(e)}")

--- a/datastew/repository/weaviate.py
+++ b/datastew/repository/weaviate.py
@@ -244,7 +244,7 @@ class WeaviateRepository(BaseRepository):
             raise RuntimeError(f"Failed to fetch concept {concept_id}: {e}")
         return concept
 
-    def get_concepts(self, limit: int, offset: int, terminology_name: Optional[str] = None) -> Page[Concept]:
+    def get_concepts(self, limit: int = 100, offset: int = 0, terminology_name: Optional[str] = None) -> Page[Concept]:
         if not self.client:
             raise ValueError("Client is not initialized or is invalid.")
         try:
@@ -918,12 +918,6 @@ class WeaviateRepository(BaseRepository):
         except Exception as e:
             raise ConnectionError(f"Failed to initialize Weaviate client: {e}")
 
-    def _process_batch(self, chunk: List[Dict[str, Any]], collection: Collection):
-        """Processes a batch of items and adds them to the Weaviate collection.
-
-        :param chunk: List of items to process.
-        :param collection: Weaviate collection instance.
-        """
     def _process_batch(self, chunk: List[Dict[str, Any]], collection: Collection):
         """Processes a batch of items and adds them to the Weaviate collection.
 


### PR DESCRIPTION
Enable OLSTerminologyImportTask to utilize Weaviate vectorizer if provided.
Calculate vectors on the fly while importing from JSONL files if vectors are not provided and `use_weaviate_vectorizer` is `False`.